### PR TITLE
withdraw logic fix

### DIFF
--- a/contracts/AelinDeal.sol
+++ b/contracts/AelinDeal.sol
@@ -157,7 +157,7 @@ contract AelinDeal is AelinVestingToken, MinimalProxyFactory, IAelinDeal {
                 : block.timestamp >= proRataRedemption.expiry,
             "redeem window still active"
         );
-        uint256 withdrawAmount = IERC20(underlyingDealToken).balanceOf(address(this)) -
+        uint256 withdrawAmount = underlyingDealTokenTotal -
             ((underlyingPerDealExchangeRate * totalUnderlyingAccepted) / 1e18);
         IERC20(underlyingDealToken).safeTransfer(holder, withdrawAmount);
         emit WithdrawUnderlyingDealToken(underlyingDealToken, holder, withdrawAmount);
@@ -230,13 +230,17 @@ contract AelinDeal is AelinVestingToken, MinimalProxyFactory, IAelinDeal {
     }
 
     /**
-     * @dev allows the purchaser to mint deal tokens. this method is also used
-     * to send deal tokens to the sponsor. It may only be called from the pool
-     * contract that created this deal
+     * @dev allows the purchaser to mint vesting tokens
      */
-    function mintVestingToken(address _to, uint256 _amount) external depositCompleted onlyPool {
-        totalUnderlyingAccepted += _amount;
-        _mintVestingToken(_to, _amount, vestingCliffExpiry);
+    function mintVestingToken(
+        address _to,
+        uint256 _escrowedAmount,
+        uint256 _underlyingAccepted
+    ) external depositCompleted onlyPool {
+        if (_underlyingAccepted > 0) {
+            totalUnderlyingAccepted += _underlyingAccepted;
+        }
+        _mintVestingToken(_to, _escrowedAmount, vestingCliffExpiry);
     }
 
     /**

--- a/contracts/AelinDeal.sol
+++ b/contracts/AelinDeal.sol
@@ -12,7 +12,7 @@ contract AelinDeal is AelinVestingToken, MinimalProxyFactory, IAelinDeal {
 
     address public underlyingDealToken;
     uint256 public underlyingDealTokenTotal;
-    uint256 public totalUnderlyingAccepted;
+    uint256 public totalDealTokenAccepted;
     uint256 public totalUnderlyingClaimed;
     uint256 public totalProtocolFee;
     address public holder;
@@ -161,7 +161,7 @@ contract AelinDeal is AelinVestingToken, MinimalProxyFactory, IAelinDeal {
             "redeem window still active"
         );
         uint256 withdrawAmount = underlyingDealTokenTotal -
-            ((underlyingPerDealExchangeRate * totalUnderlyingAccepted) / 1e18);
+            ((underlyingPerDealExchangeRate * totalDealTokenAccepted) / 1e18);
         IERC20(underlyingDealToken).safeTransfer(holder, withdrawAmount);
         emit WithdrawUnderlyingDealToken(underlyingDealToken, holder, withdrawAmount);
     }
@@ -248,7 +248,7 @@ contract AelinDeal is AelinVestingToken, MinimalProxyFactory, IAelinDeal {
         uint256 _sponsorFee,
         uint256 _protocolFee
     ) external depositCompleted onlyPool {
-        totalUnderlyingAccepted += _underlyingAmount;
+        totalDealTokenAccepted += _underlyingAmount;
         totalProtocolFee += _protocolFee;
         _mintVestingToken(_to, _underlyingAmount - _sponsorFee - _protocolFee, vestingCliffExpiry);
     }

--- a/contracts/AelinPool.sol
+++ b/contracts/AelinPool.sol
@@ -497,7 +497,7 @@ contract AelinPool is AelinERC20, MinimalProxyFactory, IAelinPool {
         require(totalSponsorFeeAmount > 0, "no sponsor fees");
 
         sponsorClaimed = true;
-        aelinDeal.mintVestingToken(sponsor, totalSponsorFeeAmount);
+        aelinDeal.mintVestingToken(sponsor, totalSponsorFeeAmount, 0);
     }
 
     /**
@@ -541,7 +541,11 @@ contract AelinPool is AelinERC20, MinimalProxyFactory, IAelinPool {
         totalSponsorFeeAmount += sponsorFeeAmt;
 
         aelinDeal.transferProtocolFee(aelinFeeAmt);
-        aelinDeal.mintVestingToken(_recipient, poolTokenDealFormatted - (sponsorFeeAmt + aelinFeeAmt));
+        aelinDeal.mintVestingToken(
+            _recipient,
+            poolTokenDealFormatted - (sponsorFeeAmt + aelinFeeAmt),
+            poolTokenDealFormatted
+        );
 
         IERC20(purchaseToken).safeTransfer(holder, _poolTokenAmount);
         emit AcceptDeal(_recipient, address(aelinDeal), _poolTokenAmount, sponsorFeeAmt, aelinFeeAmt);

--- a/contracts/AelinPool.sol
+++ b/contracts/AelinPool.sol
@@ -497,7 +497,7 @@ contract AelinPool is AelinERC20, MinimalProxyFactory, IAelinPool {
         require(totalSponsorFeeAmount > 0, "no sponsor fees");
 
         sponsorClaimed = true;
-        aelinDeal.mintVestingToken(sponsor, totalSponsorFeeAmount, 0);
+        aelinDeal.createSponsorVestingSchedule(sponsor, totalSponsorFeeAmount);
     }
 
     /**
@@ -541,11 +541,7 @@ contract AelinPool is AelinERC20, MinimalProxyFactory, IAelinPool {
         totalSponsorFeeAmount += sponsorFeeAmt;
 
         aelinDeal.transferProtocolFee(aelinFeeAmt);
-        aelinDeal.mintVestingToken(
-            _recipient,
-            poolTokenDealFormatted - (sponsorFeeAmt + aelinFeeAmt),
-            poolTokenDealFormatted
-        );
+        aelinDeal.createVestingSchedule(_recipient, poolTokenDealFormatted, sponsorFeeAmt, aelinFeeAmt);
 
         IERC20(purchaseToken).safeTransfer(holder, _poolTokenAmount);
         emit AcceptDeal(_recipient, address(aelinDeal), _poolTokenAmount, sponsorFeeAmt, aelinFeeAmt);

--- a/test/tests/AelinDeal.t.sol
+++ b/test/tests/AelinDeal.t.sol
@@ -512,7 +512,7 @@ contract AelinDealTest is Test, AelinTestUtils, IAelinDeal, IAelinVestingToken {
         vm.startPrank(dealHolderAddress);
         uint256 withdrawAmount = AelinDeal(dealNoOpenRedemptionAddress).underlyingDealTokenTotal() -
             ((AelinDeal(dealNoOpenRedemptionAddress).underlyingPerDealExchangeRate() *
-                AelinDeal(dealNoOpenRedemptionAddress).totalUnderlyingAccepted()) / 1e18);
+                AelinDeal(dealNoOpenRedemptionAddress).totalDealTokenAccepted()) / 1e18);
         uint256 dealHolderBalance = underlyingDealToken.balanceOf(dealHolderAddress);
         // holder can withdraw the remaining underlying deal tokens
         vm.expectEmit(true, true, false, true);
@@ -544,7 +544,7 @@ contract AelinDealTest is Test, AelinTestUtils, IAelinDeal, IAelinVestingToken {
         vm.startPrank(dealHolderAddress);
         uint256 withdrawAmount = AelinDeal(dealNoOpenRedemptionAddress).underlyingDealTokenTotal() -
             ((AelinDeal(dealNoOpenRedemptionAddress).underlyingPerDealExchangeRate() *
-                AelinDeal(dealNoOpenRedemptionAddress).totalUnderlyingAccepted()) / 1e18);
+                AelinDeal(dealNoOpenRedemptionAddress).totalDealTokenAccepted()) / 1e18);
         uint256 dealHolderBalance = underlyingDealToken.balanceOf(dealHolderAddress);
         // holder can withdraw the remaining underlying deal tokens
         vm.expectEmit(true, true, false, true);
@@ -652,7 +652,7 @@ contract AelinDealTest is Test, AelinTestUtils, IAelinDeal, IAelinVestingToken {
         vm.startPrank(dealHolderAddress);
         uint256 dealHolderBalance = underlyingDealToken.balanceOf(dealHolderAddress);
         uint256 withdrawAmount = AelinDeal(dealAddr).underlyingDealTokenTotal() -
-            ((AelinDeal(dealAddr).underlyingPerDealExchangeRate() * AelinDeal(dealAddr).totalUnderlyingAccepted()) / 1e18);
+            ((AelinDeal(dealAddr).underlyingPerDealExchangeRate() * AelinDeal(dealAddr).totalDealTokenAccepted()) / 1e18);
         // holder can withdraw the remaining underlying deal tokens
         vm.expectEmit(true, true, false, true);
         emit WithdrawUnderlyingDealToken(address(underlyingDealToken), dealHolderAddress, withdrawAmount);
@@ -756,7 +756,7 @@ contract AelinDealTest is Test, AelinTestUtils, IAelinDeal, IAelinVestingToken {
         vm.startPrank(dealHolderAddress);
         uint256 dealHolderBalance = underlyingDealToken.balanceOf(dealHolderAddress);
         uint256 withdrawAmount = AelinDeal(dealAddr).underlyingDealTokenTotal() -
-            ((AelinDeal(dealAddr).underlyingPerDealExchangeRate() * AelinDeal(dealAddr).totalUnderlyingAccepted()) / 1e18);
+            ((AelinDeal(dealAddr).underlyingPerDealExchangeRate() * AelinDeal(dealAddr).totalDealTokenAccepted()) / 1e18);
         // holder can withdraw the remaining underlying deal tokens
         vm.expectEmit(true, true, false, true);
         emit WithdrawUnderlyingDealToken(address(underlyingDealToken), dealHolderAddress, withdrawAmount);

--- a/test/tests/AelinPool.misc.t.sol
+++ b/test/tests/AelinPool.misc.t.sol
@@ -2205,10 +2205,7 @@ contract AelinPoolMiscTest is Test, AelinTestUtils {
             MockERC20(underlyingDealToken).balanceOf(address(AelinDeal(poolVars.dealAddress).aelinFeeEscrow())),
             underlyingProtocolFees
         );
-        assertEq(
-            AelinDeal(poolVars.dealAddress).totalUnderlyingAccepted(),
-            poolTokenDealFormatted - (sponsorFeeAmount + aelinFeeAmount)
-        );
+        assertEq(AelinDeal(poolVars.dealAddress).totalUnderlyingAccepted(), poolTokenDealFormatted);
         assertEq(MockERC20(purchaseToken).balanceOf(user2), acceptedAmount);
 
         (uint256 share, uint256 lastClaimedAt) = AelinDeal(poolVars.dealAddress).vestingDetails(0);
@@ -2305,10 +2302,7 @@ contract AelinPoolMiscTest is Test, AelinTestUtils {
             MockERC20(underlyingDealToken).balanceOf(address(AelinDeal(poolVars.dealAddress).aelinFeeEscrow())),
             underlyingProtocolFees
         );
-        assertEq(
-            AelinDeal(poolVars.dealAddress).totalUnderlyingAccepted(),
-            poolTokenDealFormatted - (sponsorFeeAmount + aelinFeeAmount)
-        );
+        assertEq(AelinDeal(poolVars.dealAddress).totalUnderlyingAccepted(), poolTokenDealFormatted);
         assertEq(MockERC20(purchaseToken).balanceOf(user2), acceptedAmount);
 
         (uint256 share, uint256 lastClaimedAt) = AelinDeal(poolVars.dealAddress).vestingDetails(0);
@@ -2405,10 +2399,7 @@ contract AelinPoolMiscTest is Test, AelinTestUtils {
             MockERC20(underlyingDealToken).balanceOf(address(AelinDeal(poolVars.dealAddress).aelinFeeEscrow())),
             underlyingProtocolFees
         );
-        assertEq(
-            AelinDeal(poolVars.dealAddress).totalUnderlyingAccepted(),
-            poolTokenDealFormatted - (sponsorFeeAmount + aelinFeeAmount)
-        );
+        assertEq(AelinDeal(poolVars.dealAddress).totalUnderlyingAccepted(), poolTokenDealFormatted);
         assertEq(MockERC20(purchaseToken).balanceOf(user2), acceptedAmount);
 
         (uint256 share, uint256 lastClaimedAt) = AelinDeal(poolVars.dealAddress).vestingDetails(0);
@@ -2509,10 +2500,7 @@ contract AelinPoolMiscTest is Test, AelinTestUtils {
             MockERC20(underlyingDealToken).balanceOf(address(AelinDeal(poolVars.dealAddress).aelinFeeEscrow())),
             underlyingProtocolFees
         );
-        assertEq(
-            AelinDeal(poolVars.dealAddress).totalUnderlyingAccepted(),
-            poolTokenDealFormatted - (sponsorFeeAmount + aelinFeeAmount)
-        );
+        assertEq(AelinDeal(poolVars.dealAddress).totalUnderlyingAccepted(), poolTokenDealFormatted);
         assertEq(MockERC20(purchaseToken).balanceOf(user2), acceptedAmount);
 
         (uint256 share, uint256 lastClaimedAt) = AelinDeal(poolVars.dealAddress).vestingDetails(0);

--- a/test/tests/AelinPool.misc.t.sol
+++ b/test/tests/AelinPool.misc.t.sol
@@ -2205,7 +2205,7 @@ contract AelinPoolMiscTest is Test, AelinTestUtils {
             MockERC20(underlyingDealToken).balanceOf(address(AelinDeal(poolVars.dealAddress).aelinFeeEscrow())),
             underlyingProtocolFees
         );
-        assertEq(AelinDeal(poolVars.dealAddress).totalUnderlyingAccepted(), poolTokenDealFormatted);
+        assertEq(AelinDeal(poolVars.dealAddress).totalDealTokenAccepted(), poolTokenDealFormatted);
         assertEq(MockERC20(purchaseToken).balanceOf(user2), acceptedAmount);
 
         (uint256 share, uint256 lastClaimedAt) = AelinDeal(poolVars.dealAddress).vestingDetails(0);
@@ -2302,7 +2302,7 @@ contract AelinPoolMiscTest is Test, AelinTestUtils {
             MockERC20(underlyingDealToken).balanceOf(address(AelinDeal(poolVars.dealAddress).aelinFeeEscrow())),
             underlyingProtocolFees
         );
-        assertEq(AelinDeal(poolVars.dealAddress).totalUnderlyingAccepted(), poolTokenDealFormatted);
+        assertEq(AelinDeal(poolVars.dealAddress).totalDealTokenAccepted(), poolTokenDealFormatted);
         assertEq(MockERC20(purchaseToken).balanceOf(user2), acceptedAmount);
 
         (uint256 share, uint256 lastClaimedAt) = AelinDeal(poolVars.dealAddress).vestingDetails(0);
@@ -2399,7 +2399,7 @@ contract AelinPoolMiscTest is Test, AelinTestUtils {
             MockERC20(underlyingDealToken).balanceOf(address(AelinDeal(poolVars.dealAddress).aelinFeeEscrow())),
             underlyingProtocolFees
         );
-        assertEq(AelinDeal(poolVars.dealAddress).totalUnderlyingAccepted(), poolTokenDealFormatted);
+        assertEq(AelinDeal(poolVars.dealAddress).totalDealTokenAccepted(), poolTokenDealFormatted);
         assertEq(MockERC20(purchaseToken).balanceOf(user2), acceptedAmount);
 
         (uint256 share, uint256 lastClaimedAt) = AelinDeal(poolVars.dealAddress).vestingDetails(0);
@@ -2500,7 +2500,7 @@ contract AelinPoolMiscTest is Test, AelinTestUtils {
             MockERC20(underlyingDealToken).balanceOf(address(AelinDeal(poolVars.dealAddress).aelinFeeEscrow())),
             underlyingProtocolFees
         );
-        assertEq(AelinDeal(poolVars.dealAddress).totalUnderlyingAccepted(), poolTokenDealFormatted);
+        assertEq(AelinDeal(poolVars.dealAddress).totalDealTokenAccepted(), poolTokenDealFormatted);
         assertEq(MockERC20(purchaseToken).balanceOf(user2), acceptedAmount);
 
         (uint256 share, uint256 lastClaimedAt) = AelinDeal(poolVars.dealAddress).vestingDetails(0);


### PR DESCRIPTION
This PR addresses a few different issues related to `withdraw()` and `withdrawExpiry()`:

- `withdrawAmount` in `withdraw()` wasn't taking protocol fee into account. Since the protocolFee (underlying deal token) is sent to an escrow contract, it decreases the contract balance. We need to make sure that, as we did with `totalUnderlyingClaimed`, `totalProtocolFee` is added into the calculation.

-  `withdrawAmount` in `withdrawExpiry()` calculation is wrong. `balance - totalAccepted` isn't correct as `balance` decreases every time someone claims or protocol fees are taken. If a deal happens for `100 tokens`, and let's say `50 tokens` are accepted in total. Withdraw amount for holder should be `100-50 = 50`. Now let's say someone claims `10 tokens` at the end of their vesting schedule. Result becomes `90-50 = 40`, which is wrong. Correct formula is `underlyingDealTokenTotal - totalUnderlyingAccepted`.

- `mintVestingToken` function removed and split into two distinct functions: 

1. `createVestingSchedule` which mints a vesting token for investors, and also updates `totalUnderlyingAccepted` with the total amount (escrowed + fees), which wasn't the case previously. To issue a correct refund amount in `withdrawExpiry()`, `totalUnderlyingAccepted` needs to take the "real" amount accepted, a.k.a the actual amount + fees. The old function was taking the amount minus fees.
A new variable `totalProtocolFee` is also incremented in this function so the refund amount in `withdraw()` takes the protocol fee into account, as explain previously.

2. `createSponsorVestingSchedule` called in `sponsorClaim` to create the sponsor's vesting schedule. Since the sponsor fee is "taken" every time an investor accepts a deal, we don't need to update `totalUnderlyingAccepted` and `totalProtocolFee` again. So this function only calls `_mintVestingToken()`
